### PR TITLE
x86-power-control: add ChassisTransistionReset

### DIFF
--- a/power-control-x86/src/power_control.cpp
+++ b/power-control-x86/src/power_control.cpp
@@ -2281,6 +2281,12 @@ int main(int argc, char* argv[])
                 sendPowerControlEvent(power_control::Event::powerCycleRequest);
                 addRestartCause(power_control::RestartCause::command);
             }
+            else if (requested ==
+                         "xyz.openbmc_project.State.Chassis.Transition.Reset")
+              {
+                sendPowerControlEvent(power_control::Event::resetRequest);
+                addRestartCause(power_control::RestartCause::command);
+              }
             else
             {
                 std::cerr << "Unrecognized chassis state transition request.\n";


### PR DESCRIPTION
Chassis.Transition.Reset used on Intel phosphor watchdog
set command setting

The BIOS FRB2 watchdog setting possibly uses related command
setting

Signed-off-by: Samuel Jiang <Samuel.Jiang@quantatw.com>